### PR TITLE
Fix typo in the definition of M

### DIFF
--- a/docs/quest-data/52-mtab.json
+++ b/docs/quest-data/52-mtab.json
@@ -6,7 +6,7 @@
     "<p>Another weird combinator base is <b>MTAB</b>.",
     "Just like the BCKW system, it consists of four combinators,",
     "representing duplication, swapping, discarding, and composition, respectively:",
-    "<code>M a = a</code>, <code>T a b = b a</code>, <code>A a b = b</code>,",
+    "<code>M a = a a</code>, <code>T a b = b a</code>, <code>A a b = b</code>,",
     "and <code>B a b c = a (b c)</code>.</p>",
     "<p>Your task is to go back to BCKW from here. Good luck!</p>"
   ],


### PR DESCRIPTION
`M` should be duplication, not identity.